### PR TITLE
fix: render valid HTML (inline style for colors, self-closing void elements, wrapped Column children, single-line conditional comments)

### DIFF
--- a/lib/column.ml
+++ b/lib/column.ml
@@ -22,7 +22,21 @@ let to_element column =
     | Some w -> ("width", string_of_int w) :: td_attributes
   in
 
-  (* Wrap in table for Outlook compatibility *)
+  (* Wrap children in <tr><td> so block elements like <h1>, <p>, <img>
+     are not direct children of <table> (which is invalid HTML and
+     Outlook drops the orphaned nodes). *)
+  let inner_td =
+    Element.Private.make @@ Element.Private.builder
+      ~tag:"td"
+      ~attributes:[]
+      ~children:column.children
+  in
+  let inner_tr =
+    Element.Private.make @@ Element.Private.builder
+      ~tag:"tr"
+      ~attributes:[]
+      ~children:[inner_td]
+  in
   let table = Element.Private.make @@ Element.Private.builder
     ~tag:"table"
     ~attributes:[
@@ -31,7 +45,7 @@ let to_element column =
       "cellspacing", "0";
       "role", "presentation";
     ]
-    ~children:column.children
+    ~children:[inner_tr]
   in
 
   Element.Private.make @@ Element.Private.builder

--- a/lib/element.ml
+++ b/lib/element.ml
@@ -58,6 +58,13 @@ let escape_html str =
   done;
   Buffer.contents result
 
+(* HTML void elements — must self-close and never carry a closing tag.
+   DOCTYPE is XHTML 1.0 Transitional, so we emit `<tag ... />` form. *)
+let is_void_element = function
+  | "area" | "base" | "br" | "col" | "embed" | "hr" | "img" | "input"
+  | "link" | "meta" | "param" | "source" | "track" | "wbr" -> true
+  | _ -> false
+
 let rec to_html = function
   | Empty -> ""
   | Text content ->
@@ -73,11 +80,17 @@ let rec to_html = function
                   |> List.map (fun (k, v) ->
                       Printf.sprintf "%s=\"%s\"" k (escape_html v))
                   |> String.concat " " in
-      let children_html = List.map to_html children |> String.concat "" in
-      if attrs = "" then
-        Printf.sprintf "<%s>%s</%s>" tag children_html tag
+      if is_void_element tag then
+        if attrs = "" then
+          Printf.sprintf "<%s />" tag
+        else
+          Printf.sprintf "<%s %s />" tag attrs
       else
-        Printf.sprintf "<%s %s>%s</%s>" tag attrs children_html tag
+        let children_html = List.map to_html children |> String.concat "" in
+        if attrs = "" then
+          Printf.sprintf "<%s>%s</%s>" tag children_html tag
+        else
+          Printf.sprintf "<%s %s>%s</%s>" tag attrs children_html tag
 
 let rec size_in_bytes = function
   | Empty -> 0

--- a/lib/heading.ml
+++ b/lib/heading.ml
@@ -30,10 +30,14 @@ let h6 ?color content = {level = H6; color; content}
 
 let to_element heading =
   let tag = level_to_tag heading.level in
+  (* Use inline style, not the HTML4 `color` attribute. The `color` attribute
+     on <h1>..<h6> is ignored by every major email client; inline
+     style="color: ..." is universally supported.
+     See https://www.caniemail.com/features/css-color/ *)
   let attributes =
     match heading.color with
     | None -> []
-    | Some color -> ["color", Color.to_css color]
+    | Some color -> ["style", Printf.sprintf "color: %s;" (Color.to_css color)]
   in
   let children = [Element.text heading.content] in
   Element.Private.make @@

--- a/lib/heading.ml
+++ b/lib/heading.ml
@@ -33,7 +33,7 @@ let to_element heading =
   (* Use inline style, not the HTML4 `color` attribute. The `color` attribute
      on <h1>..<h6> is ignored by every major email client; inline
      style="color: ..." is universally supported.
-     See https://www.caniemail.com/features/css-color/ *)
+     See https://www.caniemail.com/features/css-background-color/ *)
   let attributes =
     match heading.color with
     | None -> []

--- a/lib/paragraph.ml
+++ b/lib/paragraph.ml
@@ -15,7 +15,7 @@ let to_element paragraph =
   (* Use inline style, not the HTML4 `color` attribute. The `color` attribute
      on <p> is ignored by every major email client; inline style="color: ..."
      is universally supported.
-     See https://www.caniemail.com/features/css-color/ *)
+     See https://www.caniemail.com/features/css-background-color/ *)
   let attributes =
     match paragraph.color with
     | None -> []

--- a/lib/paragraph.ml
+++ b/lib/paragraph.ml
@@ -12,10 +12,14 @@ let v content = {content; color = None}
 
 let to_element paragraph =
   let tag = "p" in
+  (* Use inline style, not the HTML4 `color` attribute. The `color` attribute
+     on <p> is ignored by every major email client; inline style="color: ..."
+     is universally supported.
+     See https://www.caniemail.com/features/css-color/ *)
   let attributes =
     match paragraph.color with
     | None -> []
-    | Some color -> ["color", Color.to_css color]
+    | Some color -> ["style", Printf.sprintf "color: %s;" (Color.to_css color)]
   in
   let children = [Element.text paragraph.content] in
   Element.Private.make @@

--- a/lib/render.ml
+++ b/lib/render.ml
@@ -40,16 +40,14 @@ let render_email element =
       </o:OfficeDocumentSettings>
     </xml>
   </noscript>
-  <
-![endif]-->
+  <![endif]-->
   <title>Email</title>
   <!--[if mso]>
   <style>
     table { border-collapse: collapse; }
     td, th, div, p, a, h1, h2, h3, h4, h5, h6 { font-family: Arial, sans-serif; }
   </style>
-  <
-![endif]-->
+  <![endif]-->
 </head>
 <body style="margin: 0; padding: 0; word-spacing: normal; background-color: #ffffff;">
 %s

--- a/test/structure_tests.ml
+++ b/test/structure_tests.ml
@@ -85,6 +85,72 @@ let test_gmail_limit () =
 
   assert_test "Gmail Limit: Small email within limit" (String.length small_html <= 1024 * 1024)
 
+(* Test 6: Heading and Paragraph emit inline style, not the obsolete
+   HTML4 `color` attribute. Email clients ignore the `color` attribute
+   on <h1>..<h6> and <p>. *)
+let test_color_uses_inline_style () =
+  let h = Heading.h1 ~color:(Color.solid "#1a0933") "Hi" in
+  let h_html = Element.to_html (Heading.to_element h) in
+  assert_test "Heading: color uses inline style"
+    (html_contains h_html "style=\"color: #1a0933;\"");
+  assert_test "Heading: no legacy color= attribute"
+    (not (html_contains h_html "color=\"#1a0933\""));
+
+  let p = Paragraph.make ~color:(Color.solid "#6b7280") ~content:"Hi" () in
+  let p_html = Element.to_html (Paragraph.to_element p) in
+  assert_test "Paragraph: color uses inline style"
+    (html_contains p_html "style=\"color: #6b7280;\"");
+  assert_test "Paragraph: no legacy color= attribute"
+    (not (html_contains p_html "color=\"#6b7280\""))
+
+(* Test 7: Void elements self-close and have no closing tag. The DOCTYPE
+   declares XHTML 1.0 Transitional, which requires `<img />` / `<hr />`. *)
+let test_void_elements_self_close () =
+  let img = Image.v ~src:"https://example.com/x.png" ~alt:"X"
+      ~width_px:40 ~height_px:40 in
+  let img_html = Element.to_html (Image.to_element img) in
+  assert_test "Image: renders self-closing <img ... />"
+    (html_contains img_html "/>");
+  assert_test "Image: no invalid </img> closing tag"
+    (not (html_contains img_html "</img>"));
+
+  let div = Divider.v () in
+  let div_html = Element.to_html (Divider.to_element div) in
+  assert_test "Divider: renders self-closing <hr ... />"
+    (html_contains div_html "/>");
+  assert_test "Divider: no invalid </hr> closing tag"
+    (not (html_contains div_html "</hr>"))
+
+(* Test 8: Column's inner table wraps children in <tr><td> so block
+   elements are not direct children of <table> (invalid HTML that
+   Outlook drops). *)
+let test_column_wraps_children_in_tr_td () =
+  let col = Column.v [
+    Image.to_element (Image.v ~src:"https://example.com/x.png" ~alt:"X"
+                        ~width_px:40 ~height_px:40);
+    Heading.to_element (Heading.h1 "Hi");
+  ] in
+  let html = Element.to_html (Column.to_element col) in
+  assert_test "Column: inner table has <tr><td> wrapper"
+    (html_contains html "<tr><td>");
+  assert_test "Column: no naked <img> as direct table child"
+    (not (html_contains html "presentation\"><img"));
+  assert_test "Column: no naked <h1> as direct table child"
+    (not (html_contains html "presentation\"><h1"))
+
+(* Test 9: render_email conditional comments close cleanly on one line.
+   A stray newline between `<` and `![endif]-->` breaks the Outlook
+   downlevel-hidden conditional-comment contract. *)
+let test_conditional_comments_are_single_line () =
+  let body = Section.v [Heading.to_element (Heading.h1 "Hi")] in
+  match Render.render_email (Section.to_element body) with
+  | Error e -> assert_test (Printf.sprintf "render_email succeeds: %s" e) false
+  | Ok html ->
+    assert_test "render_email: <![endif]--> appears on one line"
+      (html_contains html "<![endif]-->");
+    assert_test "render_email: no split `<\\n![endif]-->`"
+      (not (html_contains html "<\n![endif]-->"))
+
 let () =
   Printf.printf "\n=== typemail Structure Tests ===\n\n";
   test_button_vml ();
@@ -92,6 +158,10 @@ let () =
   test_text_escaping ();
   test_required_attributes ();
   test_gmail_limit ();
+  test_color_uses_inline_style ();
+  test_void_elements_self_close ();
+  test_column_wraps_children_in_tr_td ();
+  test_conditional_comments_are_single_line ();
 
   Printf.printf "\n=== Summary ===\n";
   Printf.printf "Total: %d | Passed: %d | Failed: %d\n" !test_count !passed !failed;


### PR DESCRIPTION
Fixes #6.

Five independent correctness bugs in the HTML emitter that together made `Render.render_email` produce output no real email client will render correctly. Each is verified by a new structural test in `test/structure_tests.ml`.

## What changes

### 1. Heading / Paragraph use inline `style="color: ..."` instead of the HTML4 `color` attribute

`heading.ml` and `paragraph.ml` emitted `<h1 color="#1a0933">...</h1>` and `<p color="#6b7280">...</p>`. The HTML4 `color` attribute on `<h1>..<h6>` and `<p>` is obsolete and ignored by every major email client — color was effectively dropped. Swapped to inline `style="color: ...;"` (universally supported, [caniemail](https://www.caniemail.com/features/css-color/)).

### 2. Void elements self-close

`Image.to_element` and `Divider.to_element` produced `<img ... ></img>` and `<hr ... ></hr>`. `<img>` and `<hr>` are void elements; closing tags are invalid HTML5 and invalid XHTML. Added `is_void_element` to `Element.to_html` so all HTML void elements (`img`, `hr`, `br`, `input`, `meta`, `link`, etc.) emit as self-closing `<tag ... />` (XHTML 1.0 Transitional form, matching the DOCTYPE declared by `render_email`).

### 3. `Column` wraps its children in `<tr><td>`

`Column.to_element` emitted `<td><table>[children]</table></td>` where `[children]` were block elements (`<h1>`, `<p>`, `<img>`). Block elements as direct children of `<table>` without `<tr><td>` wrapping are invalid HTML; Outlook drops them and Gmail rearranges the layout unpredictably. Now emits `<td><table><tr><td>[children]</td></tr></table></td>`.

### 4. Conditional comments close on one line

The `render_email` template string had a stray newline inside `<![endif]-->`:

\`\`\`
  <
![endif]-->
\`\`\`

breaking the Outlook downlevel-hidden contract — Outlook either saw the whole block as non-MSO or skipped it. Joined the tokens back onto a single line.

## What's NOT fixed here

Putting multiple `Column`s as children of a `Section` still produces `<td><td>...</td><td>...</td></td>` because `Section` wraps all its children in a single `<td>` and each `Column` is itself a `<td>`. The right fix is a dedicated `Row` component — I'll file a separate issue for that API addition.

## Tests

`test/structure_tests.ml` gains 13 assertions (9 test functions, up from 5). All 23 currently pass:

\`\`\`
=== typemail Structure Tests ===

✓ Button: VML opening comment present
✓ Button: VML v:roundrect tag present
✓ Button: VML closing comment present
✓ Button: Fallback table present
✓ Section: Gradient CSS present
✓ Section: Fallback bgcolor present
✓ Escaping: < entity escaped
✓ Escaping: Raw script NOT present
✓ Image: alt attribute present
✓ Gmail Limit: Small email within limit
✓ Heading: color uses inline style
✓ Heading: no legacy color= attribute
✓ Paragraph: color uses inline style
✓ Paragraph: no legacy color= attribute
✓ Image: renders self-closing <img ... />
✓ Image: no invalid </img> closing tag
✓ Divider: renders self-closing <hr ... />
✓ Divider: no invalid </hr> closing tag
✓ Column: inner table has <tr><td> wrapper
✓ Column: no naked <img> as direct table child
✓ Column: no naked <h1> as direct table child
✓ render_email: <![endif]--> appears on one line
✓ render_email: no split `<\n![endif]-->`

=== Summary ===
Total: 23 | Passed: 23 | Failed: 0
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)