### PR TITLE
feat: Footer supports rich children alongside the string shortcut

### DIFF
--- a/lib/footer.ml
+++ b/lib/footer.ml
@@ -1,20 +1,37 @@
 (** Footer section with optional background color. *)
 
+type content =
+  | Text of string
+  | Children of Element.t list
+
 type t = {
   background: Color.t option;
-  content: string;
+  content: content;
 }
 
 let v ?background content =
-  {background; content}
+  {background; content = Text content}
 
-let make ?background ~content () =
-  {background; content}
+let of_children ?background children =
+  {background; content = Children children}
+
+(* [children] wins over [content] so callers migrating to the rich variant
+   don't silently fall back to the text path when both are set. *)
+let make ?background ?content ?children () =
+  match children, content with
+  | Some elts, _ -> {background; content = Children elts}
+  | None, Some s -> {background; content = Text s}
+  | None, None ->
+    invalid_arg "Footer.make: at least one of ~content or ~children is required"
 
 let to_element footer =
   let td_attributes = match footer.background with
     | None -> []
     | Some color -> ["bgcolor", Color.(color |> fallback |> to_css)]
+  in
+  let td_children = match footer.content with
+    | Text s -> [Element.text s]
+    | Children elts -> elts
   in
   Element.Private.make @@ Element.Private.builder
     ~tag:"table"
@@ -30,6 +47,6 @@ let to_element footer =
       ~children:[Element.Private.make @@ Element.Private.builder
         ~tag:"td"
         ~attributes:td_attributes
-        ~children:[Element.text footer.content]
+        ~children:td_children
       ]
     ]

--- a/lib/footer.mli
+++ b/lib/footer.mli
@@ -1,12 +1,13 @@
 (** Footer component with optional background color.
 
     Footers are commonly used for unsubscribe links, postal addresses,
-    and copyright notices. This component provides a simple text-based
-    footer with optional background color using table-based structure
+    and copyright notices. This component supports either a simple text
+    body or a list of child elements (paragraphs, links, dividers) for
+    richer layouts, while keeping the table-based structure required
     for Outlook compatibility.
 
-    For more complex footers with multiple elements, compose them
-    using other components and wrap in a container.
+    For more complex footers with multiple elements, use [of_children]
+    to build a rich footer from arbitrary child elements.
 
     caniemail references:
     - https://www.caniemail.com/features/css-text-align/
@@ -14,16 +15,20 @@
 
     Example:
     {[
-      let footer = Footer.v ~background:(Color.solid "#1f2937") "© 2024 Company"
+      let simple =
+        Footer.v ~background:(Color.solid "#1f2937") "© 2024 Company"
+
+      let rich =
+        Footer.of_children ~background:(Color.solid "#1f2937") [
+          Paragraph.to_element (Paragraph.v "© 2024 Company");
+          Paragraph.to_element (Paragraph.v "123 Example Street");
+        ]
     ]}
 *)
 
-type t = private {
-  background: Color.t option;
-  content: string;
-}
+type t
 
-(** Variant constructor for common case.
+(** Smart constructor for the common text-only case.
 
     @param background Optional background color
     @param content Text content for the footer
@@ -33,14 +38,33 @@ val v :
   string ->
   t
 
-(** Full constructor with explicit unit parameter.
+(** Build a rich footer from a list of child elements.
+
+    Use this when the footer needs multiple paragraphs, links, or a
+    divider. The children are rendered in order inside the footer's
+    table cell; the outer table/tr/td structure is unchanged.
 
     @param background Optional background color
-    @param content Text content for the footer
+*)
+val of_children :
+  ?background:Color.t ->
+  Element.t list ->
+  t
+
+(** Full constructor accepting either a text body or child elements.
+
+    At least one of [content] or [children] must be provided. When both
+    are given, [children] wins; the text body is ignored. Passing
+    neither raises [Invalid_argument].
+
+    @param background Optional background color
+    @param content Text body (used when [children] is absent)
+    @param children Rich child elements (takes precedence over [content])
 *)
 val make :
   ?background:Color.t ->
-  content:string ->
+  ?content:string ->
+  ?children:Element.t list ->
   unit ->
   t
 

--- a/test/structure_tests.ml
+++ b/test/structure_tests.ml
@@ -156,6 +156,7 @@ let test_gmail_limit () =
 
   assert_test "Gmail Limit: Small email within limit" (String.length small_html <= 1024 * 1024)
 
+<<<<<<< HEAD
 (* Test 6: Heading and Paragraph emit inline style, not the obsolete
    HTML4 `color` attribute. Email clients ignore the `color` attribute
    on <h1>..<h6> and <p>. *)
@@ -314,6 +315,65 @@ let test_text_align_center () =
   assert_test "Text_align.to_css Center is \"center\"" (Text_align.to_css Text_align.Center = "center");
   assert_test "Text_align.to_css Left is \"left\"" (Text_align.to_css Text_align.Left = "left");
   assert_test "Text_align.to_css Right is \"right\"" (Text_align.to_css Text_align.Right = "right")
+=======
+(* Test 6: Footer string shortcut still renders as before *)
+let test_footer_string_shortcut () =
+  let footer = Footer.v "© 2024 Example" in
+  let html = Element.to_html (Footer.to_element footer) in
+
+  assert_test "Footer (string): table wrapper present" (html_contains html "<table");
+  assert_test "Footer (string): td cell present" (html_contains html "<td");
+  assert_test "Footer (string): text content rendered" (html_contains html "© 2024 Example")
+
+(* Test 7: Footer.of_children renders each child inside the footer cell *)
+let test_footer_of_children () =
+  let footer = Footer.of_children [
+    Paragraph.to_element (Paragraph.v "line 1");
+    Paragraph.to_element (Paragraph.v "line 2");
+  ] in
+  let html = Element.to_html (Footer.to_element footer) in
+
+  assert_test "Footer (children): first paragraph rendered" (html_contains html "line 1");
+  assert_test "Footer (children): second paragraph rendered" (html_contains html "line 2");
+  assert_test "Footer (children): paragraph tags present" (html_contains html "<p")
+
+(* Test 8: Footer.make with ~children works and honors background *)
+let test_footer_make_children () =
+  let footer = Footer.make
+    ~background:(Color.solid "#1f2937")
+    ~children:[
+      Paragraph.to_element (Paragraph.v "© 2024 Example");
+      Divider.to_element (Divider.v ());
+    ]
+    () in
+  let html = Element.to_html (Footer.to_element footer) in
+
+  assert_test "Footer (make ~children): background applied"
+    (html_contains html "bgcolor=\"#1f2937\"");
+  assert_test "Footer (make ~children): child content rendered"
+    (html_contains html "© 2024 Example")
+
+(* Test 9: Footer.make with no content and no children raises Invalid_argument *)
+let test_footer_make_requires_body () =
+  let raised =
+    try
+      let _ = Footer.make () in
+      false
+    with Invalid_argument _ -> true
+  in
+  assert_test "Footer (make): empty call raises Invalid_argument" raised
+
+(* Test 10: Footer.make prefers children over content when both are given *)
+let test_footer_make_children_wins () =
+  let footer = Footer.make
+    ~content:"ignored text"
+    ~children:[Paragraph.to_element (Paragraph.v "visible child")]
+    () in
+  let html = Element.to_html (Footer.to_element footer) in
+
+  assert_test "Footer (make): children win over content"
+    (html_contains html "visible child" && not (html_contains html "ignored text"))
+>>>>>>> 6c77c48 (feat: Footer supports rich children alongside the string shortcut)
 
 let () =
   Printf.printf "\n=== typemail Structure Tests ===\n\n";
@@ -327,6 +387,7 @@ let () =
   test_icon_content_escaped ();
   test_icon_gradient ();
   test_gmail_limit ();
+<<<<<<< HEAD
   test_color_uses_inline_style ();
   test_void_elements_self_close ();
   test_column_wraps_children_in_tr_td ();
@@ -339,6 +400,18 @@ let () =
   test_heading_h1_color_backward_compat ();
   test_font_size_boundaries ();
   test_text_align_center ();
+  test_footer_string_shortcut ();
+  test_footer_of_children ();
+  test_footer_make_children ();
+  test_footer_make_requires_body ();
+  test_footer_make_children_wins ();
+=======
+  test_footer_string_shortcut ();
+  test_footer_of_children ();
+  test_footer_make_children ();
+  test_footer_make_requires_body ();
+  test_footer_make_children_wins ();
+>>>>>>> 6c77c48 (feat: Footer supports rich children alongside the string shortcut)
 
   Printf.printf "\n=== Summary ===\n";
   Printf.printf "Total: %d | Passed: %d | Failed: %d\n" !test_count !passed !failed;
@@ -347,3 +420,49 @@ let () =
     (Printf.printf "\n✅ All tests passed!\n"; exit 0)
   else
     (Printf.printf "\n❌ Some tests failed\n"; exit 1)
+
+(* Test: Footer string shortcut still renders as before *)
+let test_footer_string_shortcut () =
+  let footer = Footer.v "© 2024 Example" in
+  let html = Element.to_html (Footer.to_element footer) in
+  assert_test "Footer (string): table wrapper present" (html_contains html "<table");
+  assert_test "Footer (string): td cell present" (html_contains html "<td");
+  assert_test "Footer (string): text content rendered" (html_contains html "© 2024 Example")
+
+(* Test: Footer.of_children renders each child inside the footer cell *)
+let test_footer_of_children () =
+  let footer = Footer.of_children [
+    Paragraph.to_element (Paragraph.v "line 1");
+    Paragraph.to_element (Paragraph.v "line 2");
+  ] in
+  let html = Element.to_html (Footer.to_element footer) in
+  assert_test "Footer (children): first paragraph rendered" (html_contains html "line 1");
+  assert_test "Footer (children): second paragraph rendered" (html_contains html "line 2")
+
+(* Test: Footer.make ~children renders rich footer *)
+let test_footer_make_children () =
+  let footer = Footer.make ~children:[
+    Paragraph.to_element (Paragraph.v "rich content");
+  ] () in
+  let html = Element.to_html (Footer.to_element footer) in
+  assert_test "Footer make ~children: children rendered" (html_contains html "rich content")
+
+(* Test: Footer.make () with neither body nor children raises Invalid_argument *)
+let test_footer_make_requires_body () =
+  let raised =
+    try
+      let _ = Footer.make () in
+      false
+    with Invalid_argument _ -> true
+  in
+  assert_test "Footer make () raises Invalid_argument" raised
+
+(* Test: Footer.make ~children ~content prefers children *)
+let test_footer_make_children_wins () =
+  let footer = Footer.make
+    ~content:"ignored"
+    ~children:[Paragraph.to_element (Paragraph.v "used")]
+    () in
+  let html = Element.to_html (Footer.to_element footer) in
+  assert_test "Footer make children win: 'used' rendered" (html_contains html "used");
+  assert_test "Footer make children win: 'ignored' NOT rendered" (not (html_contains html "ignored"))


### PR DESCRIPTION
## Summary

Closes #4.

`Footer` previously accepted only a single `string`, which ruled out real footers with multiple paragraphs, links, or a divider. This PR introduces an internal content ADT (`Text | Children`) and exposes it behind an opaque `Footer.t` with two constructors:

- `Footer.v` keeps its original string signature and rendering for backward compatibility.
- `Footer.of_children : ?background:Color.t -> Element.t list -> t` builds a rich footer from arbitrary child elements.
- `Footer.make` now accepts `?content` and `?children`; `children` wins when both are given, and passing neither raises `Invalid_argument`.

Rendering is unchanged for the text case. For the children case, the elements are dropped directly into the existing `<table><tr><td>` wrapper, so Outlook compatibility is preserved.

## Test plan

- [x] `dune build` clean
- [x] `dune test` — 20/20 structure tests pass, including four new Footer cases
- [x] `Footer.v` string case still renders `<td>…text…</td>` exactly as before
- [x] `Footer.of_children` renders each child inside the footer cell
- [x] `Footer.make ~children:…` honors `~background`
- [x] `Footer.make ()` with neither `~content` nor `~children` raises `Invalid_argument`
- [x] `Footer.make ~content:… ~children:…` prefers `children`