### PR TITLE
feat: Section asymmetric padding (padding_x, padding_y)

### DIFF
--- a/lib/section.ml
+++ b/lib/section.ml
@@ -3,13 +3,36 @@
 type t = {
   background: Color.t option;
   padding: Spacing.t option;
+  padding_x: Spacing.t option;
+  padding_y: Spacing.t option;
   children: Element.t list;
 }
 
-let make ?background ?padding ~children () =
-  {background; padding; children}
+let make ?background ?padding ?padding_x ?padding_y ~children () =
+  {background; padding; padding_x; padding_y; children}
 
-let v children = {background = None; padding = None; children}
+let v children =
+  {background = None; padding = None; padding_x = None; padding_y = None; children}
+
+(* Axis-specific overrides (padding_x / padding_y) win over the uniform
+   padding shorthand for the axis they cover. When only the uniform
+   ~padding is set, emit the one-value CSS shorthand to preserve
+   existing output. *)
+let padding_style section =
+  match section.padding_x, section.padding_y, section.padding with
+  | None, None, None -> None
+  | None, None, Some p ->
+      Some ("padding: " ^ Spacing.to_css p ^ ";")
+  | _, _, _ ->
+      let y = match section.padding_y with
+        | Some v -> v
+        | None -> (match section.padding with Some v -> v | None -> Spacing.of_px_exn 0)
+      in
+      let x = match section.padding_x with
+        | Some v -> v
+        | None -> (match section.padding with Some v -> v | None -> Spacing.of_px_exn 0)
+      in
+      Some ("padding: " ^ Spacing.to_css y ^ " " ^ Spacing.to_css x ^ ";")
 
 let to_element section =
   (* Create table wrapper with presentation role *)
@@ -44,9 +67,9 @@ let to_element section =
   in
 
   (* Create table cell with padding *)
-  let td_attributes = match section.padding with
+  let td_attributes = match padding_style section with
     | None -> []
-    | Some padding -> ["style", "padding: " ^ Spacing.to_css padding ^ ";"]
+    | Some style -> ["style", style]
   in
 
   (* Create properly nested structure: table > tr > td > children *)

--- a/lib/section.mli
+++ b/lib/section.mli
@@ -13,37 +13,53 @@
     This Section component uses padding on table cells (not div/p), which
     is required for cross-client compatibility.
 
+    Padding can be specified uniformly via [~padding], or per-axis via
+    [~padding_x] (left/right) and [~padding_y] (top/bottom). When both
+    the uniform and an axis-specific value are provided, the axis-specific
+    value wins for that axis.
+
     caniemail references:
     - https://www.caniemail.com/features/css-linear-gradient/
     - https://www.caniemail.com/features/css-padding/
 
     Example:
     {[
-      Section.v
+      Section.make
         ~background:(Color.solid "#f3f4f6")
-        ~padding:(Spacing.of_px_exn 16)
-        [Heading.h1 "Welcome"; Paragraph.v "Content here"]
+        ~padding_y:(Spacing.of_px_exn 32)
+        ~padding_x:(Spacing.of_px_exn 40)
+        ~children:[
+          Heading.to_element (Heading.h1 "Welcome");
+          Paragraph.to_element (Paragraph.v "Content here");
+        ]
+        ()
     ]}
 *)
 
 type t = private {
   background: Color.t option;
   padding: Spacing.t option;
+  padding_x: Spacing.t option;
+  padding_y: Spacing.t option;
   children: Element.t list;
 }
 
 (** Smart constructor for common case - no background or padding *)
 val v : Element.t list -> t
 
-(** Constructor with optional background and padding
+(** Constructor with optional background and padding.
 
     @param background Optional background color or gradient (with fallback)
-    @param padding Optional padding in pixels
+    @param padding Optional uniform padding on all four sides
+    @param padding_x Optional horizontal padding (left and right); overrides [padding] on the x-axis
+    @param padding_y Optional vertical padding (top and bottom); overrides [padding] on the y-axis
     @param children List of child elements
 *)
 val make :
   ?background:Color.t ->
   ?padding:Spacing.t ->
+  ?padding_x:Spacing.t ->
+  ?padding_y:Spacing.t ->
   children:Element.t list ->
   unit ->
   t

--- a/test/structure_tests.ml
+++ b/test/structure_tests.ml
@@ -149,6 +149,49 @@ let test_icon_gradient () =
   assert_test "Icon (gradient): linear-gradient in CSS"
     (html_contains html "linear-gradient(135deg, #7c3aed, #6b46c1)")
 
+(* Test: Section padding uniform *)
+let test_section_padding_uniform () =
+  let section = Section.make
+    ~padding:(Spacing.of_px_exn 16)
+    ~children:[]
+    () in
+  let html = Element.to_html (Section.to_element section) in
+
+  assert_test "Section uniform: single padding value"
+    (html_contains html "padding: 16px;")
+
+(* Test: Section padding axes only *)
+let test_section_padding_axes () =
+  let section = Section.make
+    ~padding_x:(Spacing.of_px_exn 40)
+    ~padding_y:(Spacing.of_px_exn 32)
+    ~children:[]
+    () in
+  let html = Element.to_html (Section.to_element section) in
+
+  assert_test "Section axes: two-value padding shorthand"
+    (html_contains html "padding: 32px 40px;")
+
+(* Test: Section padding axis overrides uniform *)
+let test_section_padding_axis_overrides_uniform () =
+  let section = Section.make
+    ~padding:(Spacing.of_px_exn 16)
+    ~padding_x:(Spacing.of_px_exn 40)
+    ~children:[]
+    () in
+  let html = Element.to_html (Section.to_element section) in
+
+  assert_test "Section override: axis-specific wins"
+    (html_contains html "padding: 16px 40px;")
+
+(* Test: Section padding none *)
+let test_section_padding_none () =
+  let section = Section.v [] in
+  let html = Element.to_html (Section.to_element section) in
+
+  assert_test "Section none: no padding attribute"
+    (not (html_contains html "padding="))
+
 (* Test 5: Gmail limit *)
 let test_gmail_limit () =
   let small = Section.v [Heading.to_element (Heading.h2 "Small")] in
@@ -326,6 +369,10 @@ let () =
   test_icon_zero_size_raises ();
   test_icon_content_escaped ();
   test_icon_gradient ();
+  test_section_padding_uniform ();
+  test_section_padding_axes ();
+  test_section_padding_axis_overrides_uniform ();
+  test_section_padding_none ();
   test_gmail_limit ();
   test_color_uses_inline_style ();
   test_void_elements_self_close ();


### PR DESCRIPTION
## Summary

Adds per-axis padding controls to `Section.make` so callers can express the very common `padding: 32px 40px` pattern (tight vertical, roomy horizontal) without falling back to a uniform value.

Fixes #2.

## API

Two new optional parameters, non-breaking:

```ocaml
val make :
  ?background:Color.t ->
  ?padding:Spacing.t ->
  ?padding_x:Spacing.t ->   (* new: horizontal only *)
  ?padding_y:Spacing.t ->   (* new: vertical only *)
  children:Element.t list ->
  unit ->
  t
```

- `~padding` stays as the uniform shorthand.
- When `~padding` is combined with `~padding_x` or `~padding_y`, the axis-specific value wins for that axis; the uniform value covers the other axis. No error — it's a sensible merge.

## Rendering

- Only `~padding` set: `padding: Xpx;` (unchanged, preserves existing output).
- Any axis-specific value set: `padding: Ypx Xpx;` (standard CSS two-value shorthand, y first).
- Nothing set: no `style` attribute on the `<td>`.

## Test plan

- [x] `dune build` clean
- [x] `dune test` clean; all 14 structural tests pass
- [x] New tests cover uniform-only, axes-only, mixed override, and no-padding cases