### PR TITLE
feat: Icon component (decorative emoji/unicode in colored circle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Pre-alpha. The API is being designed; nothing is stable yet. No opam release.
 
 ## Design pillars
 
-- **React Email ergonomics, without the JS lock-in.** Compose emails from semantic components (`Section`, `Column`, `Heading`, `Paragraph`, `Button`, `Image`, `Divider`, `Spacer`, `Footer`) — not raw HTML.
+- **React Email ergonomics, without the JS lock-in.** Compose emails from semantic components (`Section`, `Column`, `Heading`, `Paragraph`, `Button`, `Image`, `Icon`, `Divider`, `Spacer`, `Footer`) — not raw HTML.
 - **No escape hatches.** MJML's `<mj-raw>` is the single biggest source of cross-client bugs in MJML codebases. typemail has no equivalent. If a pattern isn't expressible, the right answer is to add a typed component, not to punch a hole.
 - **Types enforce cross-client safety.** A gradient's record type has a required `fallback: color` field. A button requires an explicit pixel width and height. Make illegal states unrepresentable.
 - **Proper semantic elements for accessibility.** Headings are `Heading`, paragraphs are `Paragraph`, lists are `List`. No single `Text` component used for everything (the MJML a11y gap).
@@ -21,7 +21,7 @@ Pre-alpha. The API is being designed; nothing is stable yet. No opam release.
 
 typemail **is**:
 
-- **A typed DSL for email content.** Compose emails from semantic components: `Section`, `Column`, `Heading`, `Paragraph`, `Button`, `Image`, `Divider`, `Spacer`, `Footer`. No raw HTML in the author-facing surface.
+- **A typed DSL for email content.** Compose emails from semantic components: `Section`, `Column`, `Heading`, `Paragraph`, `Button`, `Image`, `Icon`, `Divider`, `Spacer`, `Footer`. No raw HTML in the author-facing surface.
 - **Cross-client safety by construction.** A gradient's record type has a required `fallback: color` field — you cannot represent a gradient without a fallback. A button requires an explicit pixel width and height (Outlook needs these inline). Illegal states are not representable.
 - **A portable renderer.** The OCaml library emits cross-client HTML (table-layout, VML fallbacks for Outlook, solid-color fallbacks before gradients, explicit pixel dimensions). The Phase 2 CLI will emit the same HTML from a text input, so consumers in any language can shell out.
 - **Accessibility-aware.** `Heading level:[`H1 | `H2 | …]` and `Paragraph` are distinct components so screen readers can distinguish structure. Images require `alt`. Unlike MJML, `Heading` is never silently downgraded to a `Text` node.

--- a/lib/dune
+++ b/lib/dune
@@ -11,6 +11,7 @@
   footer
   heading
   html_builder
+  icon
   image
   paragraph
   render

--- a/lib/icon.ml
+++ b/lib/icon.ml
@@ -1,0 +1,120 @@
+(** Decorative Icon component - emoji (or short unicode) centered in an
+    optional colored/gradient circle. *)
+
+type t = {
+  content: string;
+  background: Color.t option;
+  diameter_px: int option;
+  size_px: int;
+}
+
+let validate_args ~where ~content ~size_px ~diameter_px =
+  if content = "" then
+    invalid_arg (where ^ ": content cannot be empty");
+  if size_px <= 0 then
+    invalid_arg (where ^ ": size_px must be > 0");
+  match diameter_px with
+  | Some d when d <= 0 ->
+      invalid_arg (where ^ ": diameter_px must be > 0")
+  | _ -> ()
+
+let v ?background ?diameter_px ~size_px content =
+  validate_args ~where:"Icon.v" ~content ~size_px ~diameter_px;
+  {content; background; diameter_px; size_px}
+
+let make ?background ?diameter_px ~size_px ~content () =
+  validate_args ~where:"Icon.make" ~content ~size_px ~diameter_px;
+  {content; background; diameter_px; size_px}
+
+(* Outer wrapper: full-width centering table. Single source for both
+   bubble and plain-glyph render paths. *)
+let center_wrapper ~inner =
+  Element.Private.make @@ Element.Private.builder
+    ~tag:"table"
+    ~attributes:[
+      "border", "0";
+      "cellpadding", "0";
+      "cellspacing", "0";
+      "role", "presentation";
+      "width", "100%";
+    ]
+    ~children:[Element.Private.make @@ Element.Private.builder
+      ~tag:"tr"
+      ~attributes:[]
+      ~children:[Element.Private.make @@ Element.Private.builder
+        ~tag:"td"
+        ~attributes:["align", "center"]
+        ~children:[inner]
+      ]
+    ]
+
+let glyph_only_table ~size_px ~content =
+  let td = Element.Private.make @@ Element.Private.builder
+    ~tag:"td"
+    ~attributes:[
+      "align", "center";
+      "style",
+        Printf.sprintf "font-size: %dpx; line-height: 1;" size_px;
+    ]
+    ~children:[Element.text content]
+  in
+  let tr = Element.Private.make @@ Element.Private.builder
+    ~tag:"tr" ~attributes:[] ~children:[td]
+  in
+  Element.Private.make @@ Element.Private.builder
+    ~tag:"table"
+    ~attributes:[
+      "border", "0";
+      "cellpadding", "0";
+      "cellspacing", "0";
+      "role", "presentation";
+    ]
+    ~children:[tr]
+
+let bubble_table ~size_px ~diameter ~background ~content =
+  let bg_fallback_hex = Color.(background |> fallback |> to_css) in
+  let bg_style = Color.to_style background in
+  let style =
+    Printf.sprintf
+      "width: %dpx; height: %dpx; %s border-radius: 50%%; \
+       font-size: %dpx; line-height: %dpx; text-align: center;"
+      diameter diameter bg_style size_px diameter
+  in
+  let td = Element.Private.make @@ Element.Private.builder
+    ~tag:"td"
+    ~attributes:[
+      "width", string_of_int diameter;
+      "height", string_of_int diameter;
+      "align", "center";
+      "valign", "middle";
+      "bgcolor", bg_fallback_hex;
+      "style", style;
+    ]
+    ~children:[Element.text content]
+  in
+  let tr = Element.Private.make @@ Element.Private.builder
+    ~tag:"tr" ~attributes:[] ~children:[td]
+  in
+  Element.Private.make @@ Element.Private.builder
+    ~tag:"table"
+    ~attributes:[
+      "border", "0";
+      "cellpadding", "0";
+      "cellspacing", "0";
+      "role", "presentation";
+    ]
+    ~children:[tr]
+
+let to_element icon =
+  let inner = match icon.background with
+    | None ->
+        glyph_only_table ~size_px:icon.size_px ~content:icon.content
+    | Some background ->
+        let diameter = match icon.diameter_px with
+          | Some d -> d
+          | None -> icon.size_px * 2
+        in
+        bubble_table
+          ~size_px:icon.size_px ~diameter ~background ~content:icon.content
+  in
+  center_wrapper ~inner

--- a/lib/icon.mli
+++ b/lib/icon.mli
@@ -1,0 +1,56 @@
+(** Decorative Icon component - emoji (or short unicode) centered in an
+    optional colored/gradient circle.
+
+    Use for decorative visual accents (a user icon above a "You're
+    invited!" heading, a warning triangle above an error message).
+    Explicitly not for interactive or semantic icons - those should be
+    real [Image]s with alt text.
+
+    The circular bubble uses CSS [border-radius: 50%] on a fixed-size
+    [<td>]. Outlook Desktop ignores [border-radius] and degrades to a
+    square, which is visually acceptable for decorative elements.
+
+    caniemail references:
+    - https://www.caniemail.com/features/css-border-radius/ (graceful
+      degradation on Outlook)
+
+    Example:
+    {[
+      Icon.v
+        ~background:(Color.gradient
+          ~direction:"135deg"
+          ~colors:["#7c3aed"; "#6b46c1"]
+          ~fallback:(Color.solid "#6b46c1"))
+        ~diameter_px:80
+        ~size_px:40
+        "👥"
+    ]}
+*)
+
+type t = private {
+  content: string;
+  background: Color.t option;
+  diameter_px: int option;
+  size_px: int;
+}
+
+(** Smart constructor. [diameter_px] defaults to [size_px * 2] when a
+    [background] is provided and [diameter_px] is omitted. *)
+val v :
+  ?background:Color.t ->
+  ?diameter_px:int ->
+  size_px:int ->
+  string ->
+  t
+
+(** Full constructor with explicit unit parameter. *)
+val make :
+  ?background:Color.t ->
+  ?diameter_px:int ->
+  size_px:int ->
+  content:string ->
+  unit ->
+  t
+
+(** Convert to Element.t for rendering *)
+val to_element : t -> Element.t

--- a/lib/typemail.ml
+++ b/lib/typemail.ml
@@ -9,6 +9,7 @@ module Button = Button
 module Column = Column
 module Section = Section
 module Image = Image
+module Icon = Icon
 module Divider = Divider
 module Spacer = Spacer
 module Footer = Footer

--- a/test/structure_tests.ml
+++ b/test/structure_tests.ml
@@ -78,6 +78,77 @@ let test_required_attributes () =
   let img_html = Element.to_html (Image.to_element img) in
   assert_test "Image: alt attribute present" (html_contains img_html "alt=\"")
 
+(* Test: Icon with solid background renders circular bubble *)
+let test_icon_bubble_solid () =
+  let icon = Icon.v
+    ~background:(Color.solid "#6b46c1")
+    ~diameter_px:80
+    ~size_px:40
+    "👥" in
+  let html = Element.to_html (Icon.to_element icon) in
+
+  assert_test "Icon: border-radius 50% present"
+    (html_contains html "border-radius: 50%");
+  assert_test "Icon: bgcolor fallback present"
+    (html_contains html "bgcolor=\"#6b46c1\"");
+  assert_test "Icon: diameter width attribute present"
+    (html_contains html "width=\"80\"");
+  assert_test "Icon: font-size from size_px present"
+    (html_contains html "font-size: 40px");
+  assert_test "Icon: glyph content present"
+    (html_contains html "👥")
+
+(* Test: Icon without background renders minimal table, no bubble styling *)
+let test_icon_no_background () =
+  let icon = Icon.v ~size_px:32 "⭐" in
+  let html = Element.to_html (Icon.to_element icon) in
+
+  assert_test "Icon (no bg): font-size present"
+    (html_contains html "font-size: 32px");
+  assert_test "Icon (no bg): no border-radius"
+    (not (html_contains html "border-radius"));
+  assert_test "Icon (no bg): no bgcolor attribute"
+    (not (html_contains html "bgcolor="));
+  assert_test "Icon (no bg): glyph content present"
+    (html_contains html "⭐")
+
+(* Test: Icon validates size_px > 0 *)
+let test_icon_zero_size_raises () =
+  let raised =
+    try
+      let _ = Icon.v ~size_px:0 "X" in
+      false
+    with Invalid_argument _ -> true
+  in
+  assert_test "Icon: size_px = 0 raises Invalid_argument" raised
+
+(* Test: Icon content is HTML-escaped *)
+let test_icon_content_escaped () =
+  let icon = Icon.v ~size_px:24 "<bad>" in
+  let html = Element.to_html (Icon.to_element icon) in
+
+  assert_test "Icon: escaped entity present"
+    (html_contains html "&lt;bad&gt;");
+  assert_test "Icon: raw tag NOT present"
+    (not (html_contains html "<bad>"))
+
+(* Test: Icon with gradient emits both bgcolor fallback and background CSS *)
+let test_icon_gradient () =
+  let icon = Icon.v
+    ~background:(Color.gradient
+      ~direction:"135deg"
+      ~colors:["#7c3aed"; "#6b46c1"]
+      ~fallback:(Color.solid "#6b46c1"))
+    ~diameter_px:80
+    ~size_px:40
+    "👥" in
+  let html = Element.to_html (Icon.to_element icon) in
+
+  assert_test "Icon (gradient): bgcolor fallback present"
+    (html_contains html "bgcolor=\"#6b46c1\"");
+  assert_test "Icon (gradient): linear-gradient in CSS"
+    (html_contains html "linear-gradient(135deg, #7c3aed, #6b46c1)")
+
 (* Test 5: Gmail limit *)
 let test_gmail_limit () =
   let small = Section.v [Heading.to_element (Heading.h2 "Small")] in
@@ -91,6 +162,11 @@ let () =
   test_section_gradient_fallback ();
   test_text_escaping ();
   test_required_attributes ();
+  test_icon_bubble_solid ();
+  test_icon_no_background ();
+  test_icon_zero_size_raises ();
+  test_icon_content_escaped ();
+  test_icon_gradient ();
   test_gmail_limit ();
 
   Printf.printf "\n=== Summary ===\n";


### PR DESCRIPTION
## Summary

Adds a new `Icon` component for decorative emoji/unicode glyphs centered in an optional colored or gradient circle. Common in transactional emails (e.g. a user icon above "You're invited!").

- New `lib/icon.mli` / `lib/icon.ml` following the existing `Image`/`Section`/`Footer` shape (opaque type, `v` + `make` + `to_element`).
- Registers `module Icon = Icon` in `lib/typemail.ml` and adds `icon` to the library's `modules` stanza in `lib/dune`.
- The rendered bubble uses `border-radius: 50%` on a fixed-size `<td>`, with a `bgcolor` fallback so Outlook Desktop degrades to an acceptable square.
- For gradient backgrounds, both `bgcolor="fallback"` and `background: linear-gradient(...)` are emitted (same fallback discipline as `Section`).
- Validation: `content` non-empty, `size_px > 0`, `diameter_px > 0` (when provided); violations raise `Invalid_argument`. When `background` is set and `diameter_px` is omitted, it defaults to `size_px * 2`.
- Content is HTML-escaped via `Element.text` (emoji passes through unchanged; `<bad>` becomes `&lt;bad&gt;`).
- Tiny README touch: lists `Icon` alongside the other semantic components.

Fixes #5.

## Test plan

Added 5 new test groups to `test/structure_tests.ml` (all green):

- [x] Icon with solid `background` + `diameter_px` renders a `<td>` with `border-radius: 50%`, the correct `bgcolor`, the diameter `width`, and the expected `font-size`.
- [x] Icon without `background` renders a minimal table with only the glyph sized (no `border-radius`, no `bgcolor`).
- [x] `Icon.v ~size_px:0 "X"` raises `Invalid_argument`.
- [x] Icon content is HTML-escaped (`"<bad>"` -> `&lt;bad&gt;`, no raw tag).
- [x] Icon with gradient `background` emits both the `bgcolor` fallback and `background: linear-gradient(...)` CSS.
- [x] `dune build --root .` clean.
- [x] `dune test --root .` clean (24/24 tests passing).